### PR TITLE
#4: add PsiViewer plugin to runIde instances

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,8 @@ repositories {
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
     version = "2020.3.1"
+
+    setPlugins("PsiViewer:203-SNAPSHOT")
 }
 
 sourceSets.getByName("main") {


### PR DESCRIPTION
This PR adds the [PsiViewer plugin](https://plugins.jetbrains.com/plugin/227-psiviewer) to development IDE instances invoked by the `runIde` gradle task.

I wanted to write this like so
```kotlin
intellij {
    version = "2020.3.1"
    plugins = ["PsiViewer:203-SNAPSHOT"]
}
```

But `plugins` was marked read-only — or perhaps it's because `setPlugins()` takes varargs, not a `Collection`.

Closes #4 