### PR TITLE
Implement identifier references & find usages

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -36,5 +36,10 @@
       <option name="name" value="maven4" />
       <option name="url" value="https://cache-redirector.jetbrains.com/plugins.jetbrains.com/maven" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven3" />
+      <option name="name" value="maven3" />
+      <option name="url" value="https://cache-redirector.jetbrains.com/www.jetbrains.com/intellij-repository/snapshots" />
+    </remote-repository>
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Kotlin2JvmCompilerArguments">
+    <option name="jvmTarget" value="1.8" />
+  </component>
+</project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.grammarkit.tasks.GenerateLexer
 import org.jetbrains.grammarkit.tasks.GenerateParser
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 
 
 plugins {
@@ -22,7 +23,7 @@ repositories {
 intellij {
     version = "2020.3.1"
 
-    setPlugins("PsiViewer:203-SNAPSHOT")
+    setPlugins("PsiViewer:203-SNAPSHOT", "com.jetbrains.hackathon.indices.viewer:1.12")
 }
 
 sourceSets.getByName("main") {
@@ -52,4 +53,10 @@ tasks.register<GenerateParser>("generateSourcePawnParser") {
     pathToPsiRoot = "/org/idea_sp/parser/psi"
     targetRoot = "src/main/gen"
     purgeOldFiles = true
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
 }

--- a/src/main/grammar/SourcePawn.bnf
+++ b/src/main/grammar/SourcePawn.bnf
@@ -1,4 +1,3 @@
-
 {
   parserClass="org.idea_sp.parser.SourcePawnParser"
 
@@ -143,6 +142,10 @@
     // TODO: remove me (for live preview purposes only)
     SPACE="regexp:[ \n\r\t\f]"
   ]
+
+  implements("global_var_decl|func_decl|methodmap|methodmap_method|methodmap_prop|typedef|typedef_param_decl|typeset|struct_decl|struct_field|enum_struct_decl|enum_struct_field|enum_struct_method|func|param_decl|enum_decl|enum_item|local_decl_item")="org.idea_sp.psi.SourcePawnNamedElement"
+  mixin("global_var_decl|func_decl|methodmap|methodmap_method|methodmap_prop|typedef|typedef_param_decl|typeset|struct_decl|struct_field|enum_struct_decl|enum_struct_field|enum_struct_method|func|param_decl|enum_decl|enum_item|local_decl_item")="org.idea_sp.psi.impl.SourcePawnNamedElementImpl"
+  generateTokenAccessors="no"
 }
 
 private root ::= global*
@@ -151,19 +154,20 @@ private meta list ::= <<param>> ( COMMA <<param>> )*
 private meta list_maybe_trailing_comma ::= <<list <<param>>>> COMMA?
 
 private global ::= global_var_decl_statement
-                 | enum_decl SEMICOLON? // XXX: pull out to rule?
                  | func_decl
                  | using_stmt
                  | methodmap
                  | typedef
                  | typeset SEMICOLON?
                  | struct_decl SEMICOLON?
+                 | enum_struct_decl SEMICOLON?
+                 | enum_decl SEMICOLON?
                  | func
 
 global_var_decl_statement ::= global_var_decl SEMICOLON
                             | global_var_decl EQ global_var_initializer SEMICOLON
 
-global_var_decl ::= global_var_storage_class? CONST_KEYWORD? type_expression symbol old_dims?
+global_var_decl ::= global_var_storage_class? CONST_KEYWORD? type_expression identifier old_dims?
 global_var_storage_class ::= STATIC_KEYWORD | PUBLIC_KEYWORD
 global_var_initializer ::= struct_literal | expr
 
@@ -186,47 +190,65 @@ private tag-vector ::= LBRACE <<list symbol>> RBRACE { pin = 1 }
 private tag ::= symbol COLON { pin = 2 }
 
 struct_literal ::= LBRACE <<list_maybe_trailing_comma struct_literal_item>> RBRACE
-struct_literal_item ::= symbol EQ expr { pin = 2 }  // XXX: be more restrictive?
+struct_literal_item ::= identifier EQ expr { pin = 2 }  // XXX: be more restrictive?
 
 // NOTE: "float" is only allowed in older versions of the compiler, where it is a native.
-func_decl ::= (NATIVE_KEYWORD | FORWARD_KEYWORD) type_expression (symbol | FLOAT_TYPE) param_list SEMICOLON { pin = 1 }
+func_decl ::= func_decl_type type_expression (identifier | FLOAT_TYPE) param_list SEMICOLON {
+  pin = 1
+  methods = [
+    funcType = "/func_decl_type"
+    nameIdentifier = "/identifier"
+  ]
+}
+func_decl_type ::= NATIVE_KEYWORD | FORWARD_KEYWORD
 
 // Statement is only used in handles.inc, and the parser only allows this incantation
 using_stmt ::= USING_KEYWORD '__intrinsics__' DOT 'Handle' SEMICOLON
 
-methodmap ::= METHODMAP_KEYWORD symbol (LT symbol)? LBRACE methodmap_entry* RBRACE SEMICOLON? { pin = 1 }
+methodmap ::= METHODMAP_KEYWORD identifier (LT identifier)? LBRACE methodmap_entry* RBRACE SEMICOLON? {
+  pin = 1
+  methods = [
+    nameIdentifier="/identifier[0]"
+    extendsType="/identifier[1]"
+  ]
+}
 private methodmap_entry ::= methodmap_method | methodmap_prop
 
 methodmap_method ::= methodmap_method_decl | methodmap_method_impl
 private methodmap_method_decl ::= PUBLIC_KEYWORD STATIC_KEYWORD? NATIVE_KEYWORD? methodmap_method_ident param_list SEMICOLON { pin = 7 }
-private methodmap_method_ident ::= type_expression symbol | symbol | TILDE symbol
-private methodmap_method_impl ::= PUBLIC_KEYWORD type_expression symbol param_list stmt
+private methodmap_method_ident ::= type_expression identifier | identifier | TILDE identifier
+private methodmap_method_impl ::= PUBLIC_KEYWORD type_expression identifier param_list stmt
 
-methodmap_prop ::= PROPERTY_KEYWORD type_expression symbol LBRACE prop_decl* RBRACE { pin = 1 }
+methodmap_prop ::= PROPERTY_KEYWORD type_expression identifier LBRACE prop_decl* RBRACE { pin = 1 }
 prop_decl ::= prop_method_decl | prop_method_impl
 accessor_name ::= 'get' | 'set'
 private prop_method_decl ::= PUBLIC_KEYWORD NATIVE_KEYWORD? accessor_name param_list SEMICOLON
 private prop_method_impl ::= PUBLIC_KEYWORD accessor_name param_list stmt
 
-typedef ::= TYPEDEF_KEYWORD symbol EQ typedef_def { pin = 1 }
+typedef ::= TYPEDEF_KEYWORD identifier EQ typedef_def { pin = 1 }
 typedef_def ::= FUNCTION_TYPE type_expression typedef_param_list SEMICOLON { pin = 1 }
 private typedef_param_list ::= LPAREN <<list_maybe_trailing_comma typedef_param_decl>>? RPAREN { pin = 1 }
-private typedef_param_decl ::= CONST_KEYWORD? type_expression AND? symbol old_dims?
+typedef_param_decl ::= CONST_KEYWORD? type_expression AND? identifier old_dims?{ pin = 1 }
 
-typeset ::= TYPESET_KEYWORD symbol LBRACE typedef_def+ RBRACE { pin = 1 }
+typeset ::= TYPESET_KEYWORD identifier LBRACE typedef_def+ RBRACE { pin = 1 }
 
-struct_decl ::= STRUCT_KEYWORD symbol LBRACE struct_field* RBRACE { pin = 1 }
-struct_field ::= PUBLIC_KEYWORD CONST_KEYWORD? type_expression symbol SEMICOLON
+struct_decl ::= STRUCT_KEYWORD identifier LBRACE struct_field* RBRACE { pin = 1 }
+struct_field ::= PUBLIC_KEYWORD CONST_KEYWORD? type_expression identifier SEMICOLON { pin = 1 }
 
-func ::= func_storage_class? type_expression symbol param_list stmt
+enum_struct_decl ::= ENUM_KEYWORD STRUCT_KEYWORD identifier LBRACE /* newline */ enum_struct_item* RBRACE
+private enum_struct_item ::= enum_struct_field | enum_struct_method
+enum_struct_field ::= type_expression identifier old_dims? SEMICOLON
+enum_struct_method ::= type_expression identifier param_list stmt SEMICOLON? { pin = 3 }
+
+func ::= func_storage_class? type_expression identifier param_list stmt
 private func_storage_class ::= PUBLIC_KEYWORD
                              | STOCK_KEYWORD STATIC_KEYWORD?
                              | STATIC_KEYWORD STOCK_KEYWORD?
 
 param_list ::= LPAREN <<list param_decl>>? RPAREN { pin = 1 }
 param_decl ::= param_decl_new | param_decl_old
-private param_decl_old ::= CONST_KEYWORD? tags? AND? symbol old_dims? (EQ expr)?
-private param_decl_new ::= CONST_KEYWORD? type_expression AND? ((symbol old_dims? (EQ expr)?) | ELLIPSIS)
+private param_decl_old ::= CONST_KEYWORD? tags? AND? identifier old_dims? (EQ expr)?
+private param_decl_new ::= CONST_KEYWORD? type_expression AND? ((identifier old_dims? (EQ expr)?) | ELLIPSIS)
 
 private stmt ::= compound_stmt
                | single_stmt
@@ -266,10 +288,11 @@ break_stmt ::= BREAK_KEYWORD SEMICOLON { pin = 1 }
 
 return_stmt ::= RETURN_KEYWORD expr? SEMICOLON { pin = 1 }
 
-enum_decl ::= ENUM_KEYWORD (tag | symbol)? LBRACE <<list_maybe_trailing_comma enum_item>>? RBRACE { pin = 1 }
-enum_item ::= symbol (EQ expr)?
+enum_decl ::= ENUM_KEYWORD (tag | identifier)? LBRACE <<list_maybe_trailing_comma enum_item>>? RBRACE { pin = 1 }
+enum_item ::= identifier (EQ expr)? { pin = 1 }
 
-local_decl ::= (STATIC_KEYWORD | CONST_KEYWORD)? type_expression <<list (symbol old_dims? local_initializer?)>>
+local_decl ::= (STATIC_KEYWORD | CONST_KEYWORD)? type_expression <<list local_decl_item>>
+local_decl_item ::= identifier old_dims? local_initializer? { pin = 1 }
 private local_initializer ::= EQ expr { pin = 1 }
 
 expr ::= assignment_expr
@@ -293,7 +316,7 @@ expr ::= assignment_expr
 
 ternary_expr ::= expr QUEST expr COLON expr { pin = 2 }
 
-assignment_expr ::= primary_expr subscript? assignment_op expr {
+assignment_expr ::= primary_expr assignment_op expr {
   pin = 3
   rightAssociative = true
 }
@@ -356,7 +379,8 @@ view_as_expr ::= VIEW_AS_KEYWORD LT type_expression GT paren_expr { pin = 1 }
 new_expr ::= NEW_KEYWORD (type def_dims | call_expr) { pin = 1 }
 
 call_expr ::= (primary_expr | FLOAT_TYPE) LPAREN <<list call_arg>>? RPAREN { pin = 2 }
-call_arg ::= call_arg_value | DOT symbol EQ call_arg_value
+call_arg ::= call_arg_value | call_kwarg
+call_kwarg ::= DOT identifier EQ call_arg_value
 private call_arg_value ::= UNDERSCORE | expr
 
 post_increment_expr ::= expr PLUSPLUS { pin = 2 }
@@ -365,7 +389,10 @@ subscript_expr ::= expr subscript { pin = 2 }
 // XXX: lack of expression used for sizeof expr. is there a better way?
 private subscript ::= LBRACKET expr? RBRACKET { pin = 1 }
 
-primary_expr ::= symbol ((DOT) symbol)? subscript*
+primary_expr ::= identifier subscript* (DOT primary_expr)*
+identifier ::= symbol {
+  mixin = "org.idea_sp.psi.ext.SourcePawnIdentifierMixin"
+}
 
 paren_expr ::= LPAREN expr RPAREN { pin = 1 }
 

--- a/src/main/kotlin/org/idea_sp/SourcePawnFileType.kt
+++ b/src/main/kotlin/org/idea_sp/SourcePawnFileType.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.fileTypes.LanguageFileType
 import javax.swing.Icon
 
 object SourcePawnFileType : LanguageFileType(SourcePawnLanguage) {
-
     override fun getName(): String = "SourcePawn file"
 
     override fun getDescription(): String = "SourcePawn language file"

--- a/src/main/kotlin/org/idea_sp/SourcePawnFindUsagesProvider.kt
+++ b/src/main/kotlin/org/idea_sp/SourcePawnFindUsagesProvider.kt
@@ -1,0 +1,61 @@
+package org.idea_sp
+
+import com.intellij.lang.cacheBuilder.DefaultWordsScanner
+import com.intellij.lang.cacheBuilder.WordsScanner
+import com.intellij.lang.findUsages.FindUsagesProvider
+import com.intellij.psi.PsiElement
+import com.intellij.psi.tree.TokenSet
+import com.intellij.psi.util.parentOfType
+import org.idea_sp.psi.*
+
+class SourcePawnFindUsagesProvider : FindUsagesProvider {
+    override fun getWordsScanner(): WordsScanner
+        = DefaultWordsScanner(
+            SourcePawnLexerAdapter(),
+            TokenSet.create(SourcePawnTypes.SYMBOL),
+            SourcePawnTokenTypeSets.COMMENTS,
+            SourcePawnTokenTypeSets.LITERALS,
+        )
+
+    override fun canFindUsagesFor(psiElement: PsiElement): Boolean
+        = psiElement is SourcePawnNamedElement
+
+    override fun getHelpId(psiElement: PsiElement): String? = null
+
+    override fun getType(element: PsiElement): String {
+        return when (element) {
+            is SourcePawnLocalDeclItem -> "local variable"
+            is SourcePawnGlobalVarDecl -> "global variable"
+            is SourcePawnEnumItem -> "enum value"
+            is SourcePawnEnumDecl -> "enum type"
+            is SourcePawnParamDecl,
+            is SourcePawnTypedefParamDecl -> "parameter"
+            is SourcePawnFunc,
+            is SourcePawnFuncDecl -> "function"
+            is SourcePawnStructField -> "struct field"
+            is SourcePawnStructDecl -> "struct type"
+            is SourcePawnTypeset -> "typeset"
+            is SourcePawnTypedef -> "typedef"
+            is SourcePawnMethodmap -> "methodmap"
+            is SourcePawnMethodmapMethod -> "methodmap function"
+            is SourcePawnMethodmapProp -> "methodmap prop"
+            else -> ""  // XXX: use something generic rather than empty string?
+        }
+    }
+
+    override fun getDescriptiveName(element: PsiElement): String {
+        if (element is SourcePawnNamedElement && element.name != null) {
+            return element.name!!
+        }
+        return ""
+    }
+
+    override fun getNodeText(element: PsiElement, useFullName: Boolean): String {
+        if (element is SourcePawnLocalDeclItem) {
+            val decl = element.parentOfType<SourcePawnLocalDecl>()
+            val type = decl!!.typeExpression.text
+            return "$type ${element.identifier.text}"
+        }
+        return element.text
+    }
+}

--- a/src/main/kotlin/org/idea_sp/SourcePawnReference.kt
+++ b/src/main/kotlin/org/idea_sp/SourcePawnReference.kt
@@ -1,0 +1,43 @@
+package org.idea_sp
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.*
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.parentOfType
+import org.idea_sp.psi.*
+import org.jetbrains.annotations.NotNull
+
+class SourcePawnReference(@NotNull element: PsiElement, rangeInElement: TextRange)
+    : PsiReferenceBase<PsiElement>(element, rangeInElement), PsiPolyVariantReference
+{
+    val identifier: String = element.text
+
+    constructor(@NotNull element: PsiElement) : this(element, TextRange(0, element.text.length))
+
+    override fun resolve(): PsiElement? {
+        val resolveResults = multiResolve(false)
+        return if (resolveResults.size == 1) resolveResults[0].element else null
+    }
+
+    override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
+        val results = ArrayList<SourcePawnNamedElement>()
+
+        val func = element.parentOfType<SourcePawnFunc>()
+        if (func != null) {
+            results.addAll(
+                PsiTreeUtil
+                    .findChildrenOfAnyType(
+                        func,
+                        SourcePawnLocalDeclItem::class.java,
+                        SourcePawnParamDecl::class.java,
+                    )
+                    .filter { it.name == identifier }
+            )
+        }
+
+        val project = myElement.project
+        results.addAll(SourcePawnUtil.findGlobalDecls(project, identifier))
+
+        return results.map { PsiElementResolveResult(it) }.toTypedArray()
+    }
+}

--- a/src/main/kotlin/org/idea_sp/SourcePawnTokenTypeSets.kt
+++ b/src/main/kotlin/org/idea_sp/SourcePawnTokenTypeSets.kt
@@ -91,6 +91,14 @@ interface SourcePawnTokenTypeSets {
             SourcePawnTypes.LTLTEQ,
             SourcePawnTypes.GTGTEQ,
         )
+        val LITERALS = TokenSet.create(
+            SourcePawnTypes.INTEGER_LITERAL,
+            SourcePawnTypes.FLOAT_LITERAL,
+            SourcePawnTypes.HEX_LITERAL,
+            SourcePawnTypes.BINARY_LITERAL,
+            SourcePawnTypes.STRING_LITERAL,
+            SourcePawnTypes.CHARACTER_LITERAL,
+        )
         val STRINGS = TokenSet.create(
             SourcePawnTypes.STRING_LITERAL,
             SourcePawnTypes.CHARACTER_LITERAL,

--- a/src/main/kotlin/org/idea_sp/SourcePawnUtil.kt
+++ b/src/main/kotlin/org/idea_sp/SourcePawnUtil.kt
@@ -1,0 +1,23 @@
+package org.idea_sp
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FileTypeIndex
+import com.intellij.psi.search.GlobalSearchScope
+import org.idea_sp.psi.SourcePawnFile
+import org.idea_sp.psi.SourcePawnNamedElement
+
+
+class SourcePawnUtil {
+    companion object {
+        fun findGlobalDecls(project: Project, name: String): List<SourcePawnNamedElement> {
+            val psiManager = PsiManager.getInstance(project)
+            return (
+                FileTypeIndex
+                    .getFiles(SourcePawnFileType, GlobalSearchScope.allScope(project))
+                    .mapNotNull { psiManager.findFile(it) as SourcePawnFile? }
+                    .flatMap { it.globalDecls.filter { decl -> decl.name == name } }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/org/idea_sp/psi/SourcePawnElementType.kt
+++ b/src/main/kotlin/org/idea_sp/psi/SourcePawnElementType.kt
@@ -3,8 +3,5 @@ package org.idea_sp.psi
 import org.jetbrains.annotations.NonNls
 import com.intellij.psi.tree.IElementType
 import org.idea_sp.SourcePawnLanguage
-import com.intellij.psi.FileViewProvider
-import com.intellij.extapi.psi.PsiFileBase
-import org.idea_sp.SourcePawnFileType
 
 class SourcePawnElementType(@NonNls debugName: String) : IElementType(debugName, SourcePawnLanguage)

--- a/src/main/kotlin/org/idea_sp/psi/SourcePawnFile.kt
+++ b/src/main/kotlin/org/idea_sp/psi/SourcePawnFile.kt
@@ -4,10 +4,27 @@ import org.idea_sp.SourcePawnLanguage
 import com.intellij.psi.FileViewProvider
 import com.intellij.extapi.psi.PsiFileBase
 import com.intellij.openapi.fileTypes.FileType
+import com.intellij.psi.util.PsiTreeUtil
 import org.idea_sp.SourcePawnFileType
 
 class SourcePawnFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, SourcePawnLanguage) {
     override fun getFileType(): FileType = SourcePawnFileType
 
     override fun toString(): String = "SourcePawn File"
+
+    val globalDecls: Collection<SourcePawnNamedElement>
+        get() = PsiTreeUtil
+                    .findChildrenOfAnyType(this,
+                        // TODO: filter out non-public functions/decls
+                        SourcePawnFunc::class.java,
+                        SourcePawnGlobalVarDecl::class.java,
+                        SourcePawnFuncDecl::class.java,
+                        SourcePawnMethodmap::class.java,
+                        SourcePawnEnumItem::class.java,
+                    )
+
+    val includedFiles: Collection<SourcePawnFile>
+        get() {
+            TODO("#include is yet to be parsed")
+        }
 }

--- a/src/main/kotlin/org/idea_sp/psi/SourcePawnNamedElement.kt
+++ b/src/main/kotlin/org/idea_sp/psi/SourcePawnNamedElement.kt
@@ -1,0 +1,6 @@
+package org.idea_sp.psi
+
+import com.intellij.model.psi.PsiSymbolDeclaration
+import com.intellij.psi.PsiNameIdentifierOwner
+
+interface SourcePawnNamedElement : PsiNameIdentifierOwner, PsiSymbolDeclaration

--- a/src/main/kotlin/org/idea_sp/psi/SourcePawnTokenType.kt
+++ b/src/main/kotlin/org/idea_sp/psi/SourcePawnTokenType.kt
@@ -1,11 +1,8 @@
 package org.idea_sp.psi
 
-import org.jetbrains.annotations.NonNls
 import com.intellij.psi.tree.IElementType
 import org.idea_sp.SourcePawnLanguage
-import com.intellij.psi.FileViewProvider
-import com.intellij.extapi.psi.PsiFileBase
-import org.idea_sp.SourcePawnFileType
+import org.jetbrains.annotations.NonNls
 
 class SourcePawnTokenType(@NonNls debugName: String) : IElementType(debugName, SourcePawnLanguage) {
     override fun toString(): String = "SourcePawnTokenType." + super.toString()

--- a/src/main/kotlin/org/idea_sp/psi/ext/SourcePawnIdentifier.kt
+++ b/src/main/kotlin/org/idea_sp/psi/ext/SourcePawnIdentifier.kt
@@ -1,0 +1,16 @@
+package org.idea_sp.psi.ext
+
+import com.intellij.extapi.psi.ASTWrapperPsiElement
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiReference
+import org.idea_sp.SourcePawnReference
+import org.idea_sp.psi.SourcePawnIdentifier
+import org.idea_sp.psi.SourcePawnNamedElement
+
+abstract class SourcePawnIdentifierMixin(node: ASTNode) : ASTWrapperPsiElement(node), SourcePawnIdentifier {
+    override fun getReference(): PsiReference?
+        = when (parent) {
+            is SourcePawnNamedElement -> null
+            else -> SourcePawnReference(this)
+        }
+}

--- a/src/main/kotlin/org/idea_sp/psi/impl/SourcePawnNamedElementImpl.kt
+++ b/src/main/kotlin/org/idea_sp/psi/impl/SourcePawnNamedElementImpl.kt
@@ -1,0 +1,35 @@
+package org.idea_sp.psi.impl
+
+import com.intellij.extapi.psi.ASTWrapperPsiElement
+import com.intellij.lang.ASTNode
+import com.intellij.model.Symbol
+import com.intellij.model.psi.PsiSymbolService
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.idea_sp.psi.SourcePawnNamedElement
+import org.idea_sp.psi.SourcePawnTypes
+import org.jetbrains.annotations.NotNull
+
+
+abstract class SourcePawnNamedElementImpl(@NotNull node: ASTNode) : ASTWrapperPsiElement(node), SourcePawnNamedElement {
+    override fun getNameIdentifier(): PsiElement?
+        = node.findChildByType(SourcePawnTypes.IDENTIFIER)?.psi
+
+    override fun getName(): String? = nameIdentifier?.text
+
+    override fun setName(name: String): PsiElement {
+        TODO("Not yet implemented")
+    }
+
+    override fun getTextOffset(): Int = nameIdentifier?.textOffset ?: super.getTextOffset()
+
+    @Suppress("UnstableApiUsage")
+    override fun getDeclaringElement(): PsiElement = nameIdentifier ?: this
+
+    @Suppress("UnstableApiUsage")
+    override fun getDeclarationRange(): TextRange
+        = nameIdentifier?.textRangeInParent ?: TextRange.create(0, textLength)
+
+    @Suppress("UnstableApiUsage")
+    override fun getSymbol(): Symbol = PsiSymbolService.getInstance().asSymbol(this)
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,6 +17,8 @@
 <!--                  extensions="sp,inc" />-->
         <lang.parserDefinition language="SourcePawn"
                                implementationClass="org.idea_sp.SourcePawnParserDefinition"/>
+        <lang.findUsagesProvider language="SourcePawn"
+                                 implementationClass="org.idea_sp.SourcePawnFindUsagesProvider" />
 
         <!-- TODO: Replace syntaxHighlighterFactory with syntaxHighlighter -->
         <lang.syntaxHighlighterFactory language="SourcePawn"


### PR DESCRIPTION
# Brief

This PR adds references capable of resolving identifiers across files. This allows all top-level functions and variables to be resolved. This PR does _NOT_ implement references for types/tags, or for fields (e.g. `myCvar.IntValue`) — and, apparently, not for arrays (`ConVar myCvars[3] = {null, ...}; myCvars[0] = ...`).

This PR also implements a Find Usages provider, allowing usage lookups for those function/variable definitions capable of being resolved.

This PR also adds support for enum structs.


# Details
## References
A `SourcePawnReference` class was added, which is capable of resolving local declarations (if referencing element is within a function body) and global declarations across the entire project (there is currently no filtering to only `#include` files).

This is accomplished by scanning the function element for any matching parameter declarations or local variable declarations (if in a function); and by enumerating all SourcePawn files in the project and finding any matching global declarations within them (using the newly-introduced `SourcePawnFile.globalDecls` val). Sources of global declarations include:

 - Functions
 - Function declarations
 - Global variable declarations
 - enum items
 - Methodmaps (for constructor/instantiation expressions, e.g. `new ArrayList()`)

Also, just to note: JetBrains exposes an [experimental API for "Symbols"](https://plugins.jetbrains.com/docs/intellij/symbols.html), which appear to be a language- and PSI-independent way to reference names/variables. I'm not entirely sure the benefits of this, yet, but I implemented `PsiSymbolDeclaration` in `SourcePawnReference`, anyway. (This is what all those `@Suppress("UnstableApiUsage")` lines are about.)

### Named Elements

To support references, the `SourcePawnNamedElement` interface has been added, which is applied to all declarations of named items (_not_ to usages of those names). This interface, which implements the `PsiNameIdentifierOwner` interface, provides the means to retrieve the String name of the named element (`getName()`), the sub-element that contains the name (`getNameIdentifier()`), as well as methods which guide highlighting and navigation, so Go To Declaration places the cursor on the name (not the start of the `SourcePawnNamedElement`).

### Identifiers

`SourcePawnReference` instances come into existence through the new `SourcePawnIdentifierMixin`. This mixin is applied to all `identifier` elements — which is a new rule introduced to the grammar to replace `symbol` where semantically relevant. `SourcePawnIdentifierMixin` implements `getReference()`, the standard way to attach core language references, which returns a `SourcePawnReference` (so long as the `identifier` isn't within a named element itself — though, in the future, a reference to itself may be added; I think I recall seeing some utility for this in the docs).


## Find Usages

So the Find Usages action turned out to be implemented differently than I presumed. I had presumed implementing references was all one needed to power Find Usages, but that's not entirely true: Find Usages calls out to a lexer (`_SourcePawnLexer` in our case) to scan for symbol/identifier tokens, comment tokens, and string/literal tokens, and (I'm sorta guessing here) if any of those tokens match the name being searched, it checks the PsiElement they belong to, returning any matches whose `getReference()` resolves to the element that Find Usages was called on. (Phew, long-winded.)


# Screenie
![idea-sp_more-identifier-references](https://user-images.githubusercontent.com/33840/108613126-0f70dc80-73bd-11eb-836b-25612f651333.gif)
